### PR TITLE
fix: 作成済みパーマリンクを読み込み、トゥート追加するとパーマリンクが未完全になる

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -122,5 +122,7 @@ function loadPermalink() {
 		};
 		xhr.send(null);
 	}
+	card_list = toot_ids;
+	max_index += toot_ids.length;
 	genPermalink(toot_ids.join(","));
 }

--- a/js/index.js
+++ b/js/index.js
@@ -111,7 +111,10 @@ function loadPermalink() {
 						+ '<span class="create-at">' + timestamp + '</span>'
 						+ '<div class="e-content" lang="ja" style="display: block; direction: ltr"><p>'+ obj.content +'</p></div>'
 						+ tmp + '</div>';
-					target_div.appendChild(e);
+						e.setAttribute("id", max_index);
+						e.setAttribute("ondblclick", "deleteCard('"+ max_index +"')");
+						max_index++;
+						target_div.appendChild(e);
 				} else {
 					console.error(xhr.statusText);
 				}
@@ -122,7 +125,5 @@ function loadPermalink() {
 		};
 		xhr.send(null);
 	}
-	card_list = toot_ids;
-	max_index += toot_ids.length;
 	genPermalink(toot_ids.join(","));
 }


### PR DESCRIPTION
fix:
1. パーマリンクをロードしたら、コピーできるパーマリンクも生成される
2. パーマリンクからロードしたトゥートが削除できるように細工