### PR TITLE
fix: ページヘッダをクリックしたら編集ページに飛んでほしい

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -26,10 +26,18 @@ header {
   align-items: center;
 }
 
-header h1 {
+header h1 a {
   font-size: 2.3rem;
   color: white;
   font-family: 'Baloo Bhai', cursive;
+  text-decoration: none;
+}
+
+header h1 a:link,
+header h1 a:visited,
+header h1 a:hover,
+header h1 a:active {
+  color: white;
 }
 
 header>div, header+div{

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <body>
   <header class="container">
     <div>
-      <h1>mastogetter</h1>
+      <h1><a href="/">mastogetter</a></h1>
     </div>
   </header>
 	<div class="container flex-center">

--- a/p.html
+++ b/p.html
@@ -16,7 +16,7 @@
 <body>
   <header class="container">
     <div>
-      <h1>mastogetter</h1>
+      <h1><a href="/">mastogetter</a></h1>
     </div>
   </header>
 	<div  class="container flex-center">


### PR DESCRIPTION
#31 のリンク箇所の追加です

> ついでに表示されているまとめのURLを読み込みフォームに突っ込んでおいてくれるとなおよし。

上記についてはよくわかってないので触れていません🙏 

- `a` タグ追加によるスタイルの微修正を含んでいます