### PR TITLE
Issue #33 短縮 URL 作成ボタンの追加

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -115,6 +115,11 @@ div.area>div input:last-child {
 #copylink {
 	margin-left: 10px;
 }
+
+#submit-gitio {
+	margin-left: 5px;
+}
+
 .area input[type="button"] {
 	font-size: 15px;
 	padding: .5em;
@@ -191,7 +196,7 @@ input[type="text"] {
 }
 label {
 	font-size: 15px;
-  padding-bottom: 15px;
+	padding-bottom: 15px;
 	color: #000;
 	line-height: 1;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -17,10 +17,10 @@ p {
 	margin-block-end: 1em;
 	margin-inline-start: 0px;
 	margin-inline-end: 0px;
-  margin-top: 1em;
-  margin-bottom: 1em;
-  margin-left: 0em;
-  margin-right: 0em;
+	margin-top: 1em;
+	margin-bottom: 1em;
+	margin-left: 0em;
+	margin-right: 0em;
 }
 
 header {
@@ -200,7 +200,7 @@ label {
 
 .error {
 	display: none;
-  font-size: .8rem;
+	font-size: .8rem;
 	position: absolute;
 	width: fit-content;
 	bottom: 200%;
@@ -231,23 +231,23 @@ input:hover+.error {
 	animation-timing-function: ease-out;
 }
 @media screen and (max-width: 899px) {
-  /* width for mobile view */
-  .area{width: 90vw; height: auto;}
-  #matomain {
-    width: 100%;
-  }
-  .error {
-    font-size: .6rem;
-  }
+	/* width for mobile view */
+	.area{width: 90vw; height: auto;}
+	#matomain {
+		width: 100%;
+	}
+	.error {
+		font-size: .6rem;
+	}
 }
 
 @media screen and (max-width: 669px) {
-  /* width for mobile view */
-  .error {
-    right: -8vw ;
-    font-size 2vw;
-  }
-  label, .area input[type="text"], .area input[type="button"], #card-preview, .area a{
-    font-size: 10px;
-  }
+	/* width for mobile view */
+	.error {
+		right: -8vw ;
+		font-size 2vw;
+	}
+	label, .area input[type="text"], .area input[type="button"], #card-preview, .area a {
+		font-size: 10px;
+	}
 }

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ja">
+
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,6 +14,7 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/locale/ja.js"></script>
 </head>
+
 <body>
 	<header class="container">
 		<div>
@@ -22,12 +24,17 @@
 	<div class="container flex-center">
 		<div class="area container flex-column">
 			<div>
-				<p><label for="load">インポートするまとめのリンク</label><input type="text" id="load" placeholder="https://hidao80.github.io/mastogetter/p.html?hoge"></p>
+				<p><label for="load">インポートするまとめのリンク</label><input type="text" id="load"
+						placeholder="https://hidao80.github.io/mastogetter/p.html?hoge"></p>
 				<input type="button" value="まとめを読み込む" onclick="loadPermalink()">
 			</div>
 			<div id="domainid">
-				<p><label for="instance">インスタンス名</label><input type="text" id="instance" placeholder="https://qiitadon.com"></p>
-				<p><label for="toot-id">トゥートID or URL</label><input type="text" id="toot-id" placeholder="カーソルをあわせてヒントを表示"><span class="error">例)<br>012345678901234567<br>https://hogedon.com/web/status/012345678901234567<br>https://hogedon.com/@userid/012345678901234567</span></p>
+				<p><label for="instance">インスタンス名</label><input type="text" id="instance"
+						placeholder="https://qiitadon.com"></p>
+				<p><label for="toot-id">トゥートID or URL</label><input type="text" id="toot-id"
+						placeholder="カーソルをあわせてヒントを表示"><span
+						class="error">例)<br>012345678901234567<br>https://hogedon.com/web/status/012345678901234567<br>https://hogedon.com/@userid/012345678901234567</span>
+				</p>
 				<input type="button" value="ID or URLからプレビュー" onclick="showPreview()">
 			</div>
 			<div id="card-preview">
@@ -39,18 +46,19 @@
 			</div>
 		</div>
 		<div class="area">
-      <div>
-        <p>
-          <label for="permalink">このまとめのリンク</label>
-          <span class="container">
-            <input id="permalink" type="text" placeholder="パーマリンクが生成されます" readonly="readonly">
-            <input id="copylink" type="button" value="コピー" onclick="copyPermalink()">
-          </span>
-        </p>
-      </div>
-      <div id="cards">
-      </div>
-    </div>
-  </div>
+			<div>
+				<p>
+					<label for="permalink">このまとめのリンク</label>
+					<span class="container">
+						<input id="permalink" type="text" placeholder="パーマリンクが生成されます" readonly="readonly">
+						<input id="copylink" type="button" value="コピー" onclick="copyPermalink()">
+					</span>
+				</p>
+			</div>
+			<div id="cards">
+			</div>
+		</div>
+	</div>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -47,13 +47,14 @@
 		</div>
 		<div class="area">
 			<div>
-				<p>
+				<p><form action="https://git.io/create" method="POST" target="_blank" id="form-gitio">
 					<label for="permalink">このまとめのリンク</label>
 					<span class="container">
-						<input id="permalink" type="text" placeholder="パーマリンクが生成されます" readonly="readonly">
+						<input id="permalink" name="url" type="text" placeholder="パーマリンクが生成されます" readonly="readonly">
 						<input id="copylink" type="button" value="コピー" onclick="copyPermalink()">
+						<input id="submit-gitio" type="button" value="git.IO" onclick="submitGitIO()" title="短縮 URL を git.io で取得する">
 					</span>
-				</p>
+				</form></p>
 			</div>
 			<div id="cards">
 			</div>

--- a/js/common.js
+++ b/js/common.js
@@ -1,4 +1,5 @@
 var card_list = {};
+var toot_ids = {};
 var max_index = 0;
 
 function $(id) {
@@ -30,7 +31,8 @@ function decodePermalink(get_url_vars) {
 	}
 	let instance = instance_full.split("//")[1];
 	let toot_id = get_url_vars["t"];
-	let toot_ids = toot_id.split(',');
+
+	toot_ids = toot_id.split(',');
 	if (toot_ids[toot_ids.length-1] < "1000000000000000") {
 		// 最後の要素が 1.0+E18より小さければ、
 		// id の途中で url が切れたと判断して最後の項目を
@@ -60,10 +62,11 @@ function genPermalink(toot_csv = undefined) {
 function showCards(permalink_obj) {
 	let instance_full = permalink_obj["instance_full"];
 	let instance = permalink_obj["instance"];
-	let toot_ids = permalink_obj["toot_ids"];
 	let toot_url = "";
 	let target_div = $("cards");
 	let xhr = new XMLHttpRequest();
+
+	toot_ids = permalink_obj["toot_ids"];
 
 	for (let i = 0; i < toot_ids.length; i++) {
 		toot_url = instance_full + "/api/v1/statuses/" + toot_ids[i];
@@ -99,6 +102,7 @@ function showCards(permalink_obj) {
 		};
 		xhr.send(null);
 	}
+
 	card_list = toot_ids;
 	genPermalink(toot_ids);
 }

--- a/js/index.js
+++ b/js/index.js
@@ -71,3 +71,7 @@ function loadPermalink() {
 	showCards(permalink_obj);
 	genPermalink(toot_ids.join(","));
 }
+
+function submitGitIO() {
+	$("form-gitio").submit();
+}


### PR DESCRIPTION
「git.IO」ボタンを押すと、git.IO に飛び短縮 URL が作成＆表示されます。（`https://git.io/***` の `***` の部分が表示されます）

最初ボタン名を「短縮 URL 作成」にしたのですが、なんか収まりが悪く「git.IO」にしました。

それでも、ボタンの位置がダメちんなのでお手すきにフォローお願いします。 @yume-yu @hidao80 

<kbd><img width="100%" alt="スクリーンショット 2020-01-08 13 49 12" src="https://user-images.githubusercontent.com/11840938/71951395-44a08680-321e-11ea-9768-d07647ca764c.png"></kdb>

他にもフォローどころあると思うので、何かあればこのブランチにご自由に追加＆ PUSH してください。